### PR TITLE
PHP >= 7.1 compatible release

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -61,28 +61,18 @@ class MyAwesomeJob implements IJob
 	/** @var Database */
 	private $database;
 	
-	/**
-	 * @param Database $database
-	 */
 	public function __construct(Database $database)
 	{
 		$this->database = $database;
 	}
 
-	/**
-	 * @param DateTime $dateTime
-	 * @return bool
-	 */
-	public function isDue(DateTime $dateTime)
+	public function isDue(DateTime $dateTime): bool
 	{
 		//$this->database->...
 		return TRUE; // When is job ready to run
 	}
 
-	/**
-	 * @return void
-	 */
-	public function run()
+	public function run(): void
 	{
 		// Do something
 	}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@
 # Composer
 /vendor
 /composer.lock
+
+# Tests
+/temp/
+/tests/DI/temp/
+/coverage.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: php
 php:
-    - 5.6
-    - 7.0
     - 7.1
     - 7.2
 
@@ -15,13 +13,6 @@ script:
 
 jobs:
   include:
-    - env: title="Lowest Dependencies 5.6"
-      php: 5.6
-      install:
-        - travis_retry composer update --no-progress --prefer-dist --prefer-lowest
-      script:
-        - composer run-script phpunit
-
     - env: title="Lowest Dependencies 7.1"
       php: 7.1
       install:

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     }
   ],
   "require": {
-    "php": ">=5.6",
+    "php": ">=7.1",
     "dragonmantank/cron-expression": "^1.2.1",
     "nette/di": "^2.4.10",
     "symfony/console": "^3.3.14"

--- a/composer.json
+++ b/composer.json
@@ -27,10 +27,10 @@
     "symfony/console": "^3.3.14 || ^4.0.0"
   },
   "require-dev": {
-    "ninjify/qa": "~0.8.0",
+    "ninjify/qa": "^0.8.0",
     "mockery/mockery": "~1.0.0",
     "phpunit/phpunit": "~5.7.27",
-    "tracy/tracy": "2.4.9"
+    "tracy/tracy": "~2.4.14"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "php": ">=7.1",
     "dragonmantank/cron-expression": "^1.2.1",
     "nette/di": "^2.4.10",
-    "symfony/console": "^3.3.14"
+    "symfony/console": "^3.3.14 || ^4.0.0"
   },
   "require-dev": {
     "ninjify/qa": "~0.4.0",

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,14 @@
 {
   "name": "contributte/scheduler",
   "description": "PHP job scheduler (cron) with locking",
-  "keywords": ["nette", "cron"],
+  "keywords": [
+    "nette",
+    "cron"
+  ],
+  "license": [
+    "MIT"
+  ],
   "type": "library",
-  "license": ["MIT"],
   "homepage": "https://github.com/contributte/scheduler",
   "authors": [
     {
@@ -22,9 +27,10 @@
     "symfony/console": "^3.3.14 || ^4.0.0"
   },
   "require-dev": {
-    "ninjify/qa": "~0.4.0",
-    "mockery/mockery": "~1.0",
-    "phpunit/phpunit": "~5.7.26"
+    "ninjify/qa": "~0.8.0",
+    "mockery/mockery": "~1.0.0",
+    "phpunit/phpunit": "~5.7.27",
+    "tracy/tracy": "2.4.9"
   },
   "autoload": {
     "psr-4": {
@@ -36,33 +42,32 @@
       "Tests\\Contributte\\Scheduler\\": "tests/"
     }
   },
+  "minimum-stability": "dev",
+  "prefer-stable": true,
   "scripts": {
-    "qa": [
-      "linter src tests",
-      "codesniffer src tests"
-    ],
     "ci": [
       "@qa",
       "@phpstan",
       "@phpunit"
     ],
-    "phpstan-install": [
-      "mkdir -p temp/phpstan",
-      "composer require -d temp/phpstan phpstan/phpstan"
-    ],
-    "phpstan": [
-      "temp/phpstan/vendor/bin/phpstan analyse -l 7 -c phpstan.neon src"
+    "qa": [
+      "linter src tests",
+      "codesniffer src tests"
     ],
     "phpunit": [
       "phpunit tests --colors=always"
     ],
     "coverage": [
       "phpunit tests --colors=always -c tests/coverage.xml"
+    ],
+    "phpstan-install": [
+      "mkdir -p temp/phpstan",
+      "composer require -d temp/phpstan phpstan/phpstan:0.9.2",
+      "composer require -d temp/phpstan phpstan/phpstan-nette:0.9",
+      "composer require -d temp/phpstan phpstan/phpstan-strict-rules:0.9"
+    ],
+    "phpstan": [
+      "temp/phpstan/vendor/bin/phpstan analyse -l max -c phpstan.neon src"
     ]
-  },
-  "extra": {
-    "branch-alias": {
-      "dev-master": "0.1.x-dev"
-    }
   }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,4 @@
-parameters:
-	ignoreErrors:
-		- '#Call to static method log\(\) on an unknown class Tracy\\Debugger.#'
+includes:
+	- temp/phpstan/vendor/phpstan/phpstan-strict-rules/rules.neon
+	- temp/phpstan/vendor/phpstan/phpstan-nette/extension.neon
+	- temp/phpstan/vendor/phpstan/phpstan-nette/rules.neon

--- a/src/CallbackJob.php
+++ b/src/CallbackJob.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Contributte\Scheduler;
 
 class CallbackJob extends ExpressionJob
@@ -8,28 +10,18 @@ class CallbackJob extends ExpressionJob
 	/** @var callable */
 	private $callback;
 
-	/**
-	 * @param string $cron
-	 * @param callable $callback
-	 */
-	public function __construct($cron, $callback)
+	public function __construct(string $cron, callable $callback)
 	{
 		parent::__construct($cron);
 		$this->callback = $callback;
 	}
 
-	/**
-	 * @return void
-	 */
-	public function run()
+	public function run(): void
 	{
 		call_user_func($this->callback);
 	}
 
-	/**
-	 * @return callable
-	 */
-	public function getCallback()
+	public function getCallback(): callable
 	{
 		return $this->callback;
 	}

--- a/src/CallbackJob.php
+++ b/src/CallbackJob.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace Contributte\Scheduler;
 

--- a/src/Command/HelpCommand.php
+++ b/src/Command/HelpCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Contributte\Scheduler\Command;
 
 use Symfony\Component\Console\Command\Command;
@@ -9,21 +11,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 class HelpCommand extends Command
 {
 
-	/**
-	 * @return void
-	 */
-	protected function configure()
+	protected function configure(): void
 	{
 		$this->setName('scheduler:help')
 			->setDescription('Print cron syntax');
 	}
 
-	/**
-	 * @param InputInterface $input
-	 * @param OutputInterface $output
-	 * @return int
-	 */
-	protected function execute(InputInterface $input, OutputInterface $output)
+	protected function execute(InputInterface $input, OutputInterface $output): int
 	{
 		$output->writeln('Cron syntax: ');
 		$output->writeln('

--- a/src/Command/HelpCommand.php
+++ b/src/Command/HelpCommand.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace Contributte\Scheduler\Command;
 

--- a/src/Command/ListCommand.php
+++ b/src/Command/ListCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Contributte\Scheduler\Command;
 
 use Contributte\Scheduler\CallbackJob;
@@ -18,30 +20,19 @@ class ListCommand extends Command
 	/** @var IScheduler */
 	private $scheduler;
 
-	/**
-	 * @param IScheduler $scheduler
-	 */
 	public function __construct(IScheduler $scheduler)
 	{
 		parent::__construct();
 		$this->scheduler = $scheduler;
 	}
 
-	/**
-	 * @return void
-	 */
-	protected function configure()
+	protected function configure(): void
 	{
 		$this->setName('scheduler:list')
 			->setDescription('List all scheduler jobs');
 	}
 
-	/**
-	 * @param InputInterface $input
-	 * @param OutputInterface $output
-	 * @return int
-	 */
-	protected function execute(InputInterface $input, OutputInterface $output)
+	protected function execute(InputInterface $input, OutputInterface $output): int
 	{
 		$jobs = $this->scheduler->getAll();
 		$table = new Table($output);
@@ -55,12 +46,9 @@ class ListCommand extends Command
 	}
 
 	/**
-	 * @param string $key
-	 * @param IJob $job
-	 * @param DateTime $dateTime
 	 * @return string[]
 	 */
-	private static function formatRow($key, IJob $job, DateTime $dateTime)
+	private static function formatRow(string $key, IJob $job, DateTime $dateTime): array
 	{
 		// Common
 		$row = [

--- a/src/Command/ListCommand.php
+++ b/src/Command/ListCommand.php
@@ -13,6 +13,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use DateTimeInterface;
 
 class ListCommand extends Command
 {
@@ -48,7 +49,7 @@ class ListCommand extends Command
 	/**
 	 * @return string[]
 	 */
-	private static function formatRow(string $key, IJob $job, DateTime $dateTime): array
+	private static function formatRow(string $key, IJob $job, DateTimeInterface $dateTime): array
 	{
 		// Common
 		$row = [

--- a/src/Command/ListCommand.php
+++ b/src/Command/ListCommand.php
@@ -24,6 +24,25 @@ class ListCommand extends Command
 		$this->scheduler = $scheduler;
 	}
 
+	protected function configure(): void
+	{
+		$this->setName('scheduler:list')
+			->setDescription('List all scheduler jobs');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int
+	{
+		$jobs = $this->scheduler->getAll();
+		$table = new Table($output);
+		$table->setHeaders(['Key', 'Type', 'Is due', 'Cron', 'Callback']);
+		$dateTime = new DateTime();
+		foreach ($jobs as $key => $job) {
+			$table->addRow(self::formatRow($key, $job, $dateTime));
+		}
+		$table->render();
+		return 0;
+	}
+
 	/**
 	 * @return string[]
 	 */
@@ -48,25 +67,6 @@ class ListCommand extends Command
 			$row[] = 'Dynamic';
 		}
 		return $row;
-	}
-
-	protected function configure(): void
-	{
-		$this->setName('scheduler:list')
-			->setDescription('List all scheduler jobs');
-	}
-
-	protected function execute(InputInterface $input, OutputInterface $output): int
-	{
-		$jobs = $this->scheduler->getAll();
-		$table = new Table($output);
-		$table->setHeaders(['Key', 'Type', 'Is due', 'Cron', 'Callback']);
-		$dateTime = new DateTime();
-		foreach ($jobs as $key => $job) {
-			$table->addRow(self::formatRow($key, $job, $dateTime));
-		}
-		$table->render();
-		return 0;
 	}
 
 }

--- a/src/Command/ListCommand.php
+++ b/src/Command/ListCommand.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace Contributte\Scheduler\Command;
 
@@ -13,7 +11,6 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use DateTimeInterface;
 
 class ListCommand extends Command
 {
@@ -27,29 +24,10 @@ class ListCommand extends Command
 		$this->scheduler = $scheduler;
 	}
 
-	protected function configure(): void
-	{
-		$this->setName('scheduler:list')
-			->setDescription('List all scheduler jobs');
-	}
-
-	protected function execute(InputInterface $input, OutputInterface $output): int
-	{
-		$jobs = $this->scheduler->getAll();
-		$table = new Table($output);
-		$table->setHeaders(['Key', 'Type', 'Is due', 'Cron', 'Callback']);
-		$dateTime = new DateTime();
-		foreach ($jobs as $key => $job) {
-			$table->addRow(self::formatRow($key, $job, $dateTime));
-		}
-		$table->render();
-		return 0;
-	}
-
 	/**
 	 * @return string[]
 	 */
-	private static function formatRow(string $key, IJob $job, DateTimeInterface $dateTime): array
+	private static function formatRow(string $key, IJob $job, DateTime $dateTime): array
 	{
 		// Common
 		$row = [
@@ -70,6 +48,25 @@ class ListCommand extends Command
 			$row[] = 'Dynamic';
 		}
 		return $row;
+	}
+
+	protected function configure(): void
+	{
+		$this->setName('scheduler:list')
+			->setDescription('List all scheduler jobs');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int
+	{
+		$jobs = $this->scheduler->getAll();
+		$table = new Table($output);
+		$table->setHeaders(['Key', 'Type', 'Is due', 'Cron', 'Callback']);
+		$dateTime = new DateTime();
+		foreach ($jobs as $key => $job) {
+			$table->addRow(self::formatRow($key, $job, $dateTime));
+		}
+		$table->render();
+		return 0;
 	}
 
 }

--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Contributte\Scheduler\Command;
 
 use Contributte\Scheduler\IScheduler;
@@ -13,30 +15,19 @@ class RunCommand extends Command
 	/** @var IScheduler */
 	private $scheduler;
 
-	/**
-	 * @param IScheduler $scheduler
-	 */
 	public function __construct(IScheduler $scheduler)
 	{
 		parent::__construct();
 		$this->scheduler = $scheduler;
 	}
 
-	/**
-	 * @return void
-	 */
-	protected function configure()
+	protected function configure(): void
 	{
 		$this->setName('scheduler:run')
 			->setDescription('Run scheduler jobs');
 	}
 
-	/**
-	 * @param InputInterface $input
-	 * @param OutputInterface $output
-	 * @return int
-	 */
-	protected function execute(InputInterface $input, OutputInterface $output)
+	protected function execute(InputInterface $input, OutputInterface $output): int
 	{
 		$this->scheduler->run();
 		return 0;

--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace Contributte\Scheduler\Command;
 

--- a/src/DI/SchedulerExtension.php
+++ b/src/DI/SchedulerExtension.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace Contributte\Scheduler\DI;
 
@@ -38,13 +36,13 @@ class SchedulerExtension extends CompilerExtension
 		// Commands
 		$builder->addDefinition($this->prefix('runCommand'))
 			->setClass(RunCommand::class)
-			->setAutowired(FALSE);
+			->setAutowired(false);
 		$builder->addDefinition($this->prefix('listCommand'))
 			->setClass(ListCommand::class)
-			->setAutowired(FALSE);
+			->setAutowired(false);
 		$builder->addDefinition($this->prefix('helpCommand'))
 			->setClass(HelpCommand::class)
-			->setAutowired(FALSE);
+			->setAutowired(false);
 
 		// Jobs
 		foreach ($config['jobs'] as $job) {

--- a/src/DI/SchedulerExtension.php
+++ b/src/DI/SchedulerExtension.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Contributte\Scheduler\DI;
 
 use Contributte\Scheduler\CallbackJob;
@@ -22,10 +24,8 @@ class SchedulerExtension extends CompilerExtension
 
 	/**
 	 * Register services
-	 *
-	 * @return void
 	 */
-	public function loadConfiguration()
+	public function loadConfiguration(): void
 	{
 		$builder = $this->getContainerBuilder();
 		$config = $this->validateConfig($this->defaults);

--- a/src/ExpressionJob.php
+++ b/src/ExpressionJob.php
@@ -5,7 +5,7 @@ declare(strict_types = 1);
 namespace Contributte\Scheduler;
 
 use Cron\CronExpression;
-use DateTime;
+use DateTimeInterface;
 
 abstract class ExpressionJob implements IJob
 {
@@ -18,7 +18,7 @@ abstract class ExpressionJob implements IJob
 		$this->expression = CronExpression::factory($cron);
 	}
 
-	public function isDue(DateTime $dateTime): bool
+	public function isDue(DateTimeInterface $dateTime): bool
 	{
 		return $this->expression->isDue($dateTime);
 	}

--- a/src/ExpressionJob.php
+++ b/src/ExpressionJob.php
@@ -1,11 +1,9 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace Contributte\Scheduler;
 
 use Cron\CronExpression;
-use DateTimeInterface;
+use DateTime;
 
 abstract class ExpressionJob implements IJob
 {
@@ -18,7 +16,7 @@ abstract class ExpressionJob implements IJob
 		$this->expression = CronExpression::factory($cron);
 	}
 
-	public function isDue(DateTimeInterface $dateTime): bool
+	public function isDue(DateTime $dateTime): bool
 	{
 		return $this->expression->isDue($dateTime);
 	}

--- a/src/ExpressionJob.php
+++ b/src/ExpressionJob.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Contributte\Scheduler;
 
 use Cron\CronExpression;
@@ -11,27 +13,17 @@ abstract class ExpressionJob implements IJob
 	/** @var CronExpression */
 	protected $expression;
 
-	/**
-	 * @param string $cron
-	 */
-	public function __construct($cron)
+	public function __construct(string $cron)
 	{
 		$this->expression = CronExpression::factory($cron);
 	}
 
-	/**
-	 * @param DateTime $dateTime
-	 * @return bool
-	 */
-	public function isDue(DateTime $dateTime)
+	public function isDue(DateTime $dateTime): bool
 	{
 		return $this->expression->isDue($dateTime);
 	}
 
-	/**
-	 * @return CronExpression
-	 */
-	public function getExpression()
+	public function getExpression(): CronExpression
 	{
 		return $this->expression;
 	}

--- a/src/Helpers/Debugger.php
+++ b/src/Helpers/Debugger.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Contributte\Scheduler\Helpers;
 
 use Exception;
@@ -7,11 +9,7 @@ use Exception;
 class Debugger
 {
 
-	/**
-	 * @param Exception $e
-	 * @return void
-	 */
-	public static function log(Exception $e)
+	public static function log(Exception $e): void
 	{
 		if (class_exists('\Tracy\Debugger')) {
 			\Tracy\Debugger::log($e);

--- a/src/Helpers/Debugger.php
+++ b/src/Helpers/Debugger.php
@@ -1,18 +1,17 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace Contributte\Scheduler\Helpers;
 
-use Exception;
+use Throwable;
+use Tracy\Debugger as TracyDebugger;
 
 class Debugger
 {
 
-	public static function log(Exception $e): void
+	public static function log(Throwable $e): void
 	{
-		if (class_exists('\Tracy\Debugger')) {
-			\Tracy\Debugger::log($e);
+		if (class_exists(TracyDebugger::class)) {
+			TracyDebugger::log($e);
 		}
 	}
 

--- a/src/IJob.php
+++ b/src/IJob.php
@@ -1,15 +1,13 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace Contributte\Scheduler;
 
-use DateTimeInterface;
+use DateTime;
 
 interface IJob
 {
 
-	public function isDue(DateTimeInterface $dateTime): bool;
+	public function isDue(DateTime $dateTime): bool;
 
 	public function run(): void;
 

--- a/src/IJob.php
+++ b/src/IJob.php
@@ -4,12 +4,12 @@ declare(strict_types = 1);
 
 namespace Contributte\Scheduler;
 
-use DateTime;
+use DateTimeInterface;
 
 interface IJob
 {
 
-	public function isDue(DateTime $dateTime): bool;
+	public function isDue(DateTimeInterface $dateTime): bool;
 
 	public function run(): void;
 

--- a/src/IJob.php
+++ b/src/IJob.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Contributte\Scheduler;
 
 use DateTime;
@@ -7,15 +9,8 @@ use DateTime;
 interface IJob
 {
 
-	/**
-	 * @param DateTime $dateTime
-	 * @return bool
-	 */
-	public function isDue(DateTime $dateTime);
+	public function isDue(DateTime $dateTime): bool;
 
-	/**
-	 * @return void
-	 */
-	public function run();
+	public function run(): void;
 
 }

--- a/src/IScheduler.php
+++ b/src/IScheduler.php
@@ -9,16 +9,25 @@ interface IScheduler
 
 	public function run(): void;
 
-	public function add(IJob $job, ?string $key = NULL): void;
+    /**
+     * @param string|int|null $key
+     */
+	public function add(IJob $job, $key = NULL): void;
 
-	public function get(string $key): ?IJob;
+    /**
+     * @param string|int $key
+     */
+	public function get($key): ?IJob;
 
 	/**
 	 * @return IJob[]
 	 */
 	public function getAll(): array;
 
-	public function remove(string $key): void;
+    /**
+     * @param string|int $key
+     */
+	public function remove($key): void;
 
 	public function removeAll(): void;
 

--- a/src/IScheduler.php
+++ b/src/IScheduler.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace Contributte\Scheduler;
 
@@ -12,7 +10,7 @@ interface IScheduler
     /**
      * @param string|int|null $key
      */
-	public function add(IJob $job, $key = NULL): void;
+	public function add(IJob $job, $key = null): void;
 
     /**
      * @param string|int $key

--- a/src/IScheduler.php
+++ b/src/IScheduler.php
@@ -1,42 +1,25 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Contributte\Scheduler;
 
 interface IScheduler
 {
 
-	/**
-	 * @return void
-	 */
-	public function run();
+	public function run(): void;
 
-	/**
-	 * @param IJob $job
-	 * @param string|NULL $key
-	 * @return void
-	 */
-	public function add(IJob $job, $key = NULL);
+	public function add(IJob $job, ?string $key = NULL): void;
 
-	/**
-	 * @param string $key
-	 * @return IJob|NULL
-	 */
-	public function get($key);
+	public function get(string $key): ?IJob;
 
 	/**
 	 * @return IJob[]
 	 */
-	public function getAll();
+	public function getAll(): array;
 
-	/**
-	 * @param string $key
-	 * @return void
-	 */
-	public function remove($key);
+	public function remove(string $key): void;
 
-	/**
-	 * @return void
-	 */
-	public function removeAll();
+	public function removeAll(): void;
 
 }

--- a/src/LockingScheduler.php
+++ b/src/LockingScheduler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Contributte\Scheduler;
 
 use Contributte\Scheduler\Helpers\Debugger;
@@ -11,18 +13,12 @@ class LockingScheduler extends Scheduler
 	/** @var string */
 	protected $path;
 
-	/**
-	 * @param string $path
-	 */
-	public function __construct($path)
+	public function __construct(string $path)
 	{
 		$this->path = $path;
 	}
 
-	/**
-	 * @return void
-	 */
-	public function run()
+	public function run(): void
 	{
 		if (!file_exists($this->path)) {
 			mkdir($this->path, 0777, TRUE);

--- a/src/Scheduler.php
+++ b/src/Scheduler.php
@@ -28,7 +28,10 @@ class Scheduler implements IScheduler
 		}
 	}
 
-	public function add(IJob $job, ?string $key = NULL): void
+    /**
+     * @param string|int|null $key
+     */
+	public function add(IJob $job, $key = NULL): void
 	{
 		if ($key !== NULL) {
 			$this->jobs[$key] = $job;
@@ -37,7 +40,10 @@ class Scheduler implements IScheduler
 		$this->jobs[] = $job;
 	}
 
-	public function get(string $key): ?IJob
+    /**
+     * @param string|int $key
+     */
+	public function get($key): ?IJob
 	{
 		return isset($this->jobs[$key]) ? $this->jobs[$key] : NULL;
 	}
@@ -50,7 +56,10 @@ class Scheduler implements IScheduler
 		return $this->jobs;
 	}
 
-	public function remove(string $key): void
+    /**
+     * @param string|int $key
+     */
+	public function remove($key): void
 	{
 		unset($this->jobs[$key]);
 	}

--- a/src/Scheduler.php
+++ b/src/Scheduler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Contributte\Scheduler;
 
 use Contributte\Scheduler\Helpers\Debugger;
@@ -11,10 +13,7 @@ class Scheduler implements IScheduler
 	/** @var IJob[] */
 	protected $jobs = [];
 
-	/**
-	 * @return void
-	 */
-	public function run()
+	public function run(): void
 	{
 		$dateTime = new DateTime();
 		$jobs = $this->jobs;
@@ -29,12 +28,7 @@ class Scheduler implements IScheduler
 		}
 	}
 
-	/**
-	 * @param IJob $job
-	 * @param string|NULL $key
-	 * @return void
-	 */
-	public function add(IJob $job, $key = NULL)
+	public function add(IJob $job, ?string $key = NULL): void
 	{
 		if ($key !== NULL) {
 			$this->jobs[$key] = $job;
@@ -43,11 +37,7 @@ class Scheduler implements IScheduler
 		$this->jobs[] = $job;
 	}
 
-	/**
-	 * @param string $key
-	 * @return IJob|NULL
-	 */
-	public function get($key)
+	public function get(string $key): ?IJob
 	{
 		return isset($this->jobs[$key]) ? $this->jobs[$key] : NULL;
 	}
@@ -55,24 +45,17 @@ class Scheduler implements IScheduler
 	/**
 	 * @return IJob[]
 	 */
-	public function getAll()
+	public function getAll(): array
 	{
 		return $this->jobs;
 	}
 
-	/**
-	 * @param string $key
-	 * @return void
-	 */
-	public function remove($key)
+	public function remove(string $key): void
 	{
 		unset($this->jobs[$key]);
 	}
 
-	/**
-	 * @return void
-	 */
-	public function removeAll()
+	public function removeAll(): void
 	{
 		$this->jobs = [];
 	}

--- a/src/Scheduler.php
+++ b/src/Scheduler.php
@@ -1,11 +1,10 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace Contributte\Scheduler;
 
 use Contributte\Scheduler\Helpers\Debugger;
 use DateTime;
+use Throwable;
 
 class Scheduler implements IScheduler
 {
@@ -18,34 +17,35 @@ class Scheduler implements IScheduler
 		$dateTime = new DateTime();
 		$jobs = $this->jobs;
 		foreach ($jobs as $job) {
-			if (!$job->isDue($dateTime))
+			if (!$job->isDue($dateTime)) {
 				continue;
+			}
 			try {
 				$job->run();
-			} catch (\Exception $e) {
+			} catch (Throwable $e) {
 				Debugger::log($e);
 			}
 		}
 	}
 
-    /**
-     * @param string|int|null $key
-     */
-	public function add(IJob $job, $key = NULL): void
+	/**
+	 * @param string|int|null $key
+	 */
+	public function add(IJob $job, $key = null): void
 	{
-		if ($key !== NULL) {
+		if ($key !== null) {
 			$this->jobs[$key] = $job;
 			return;
 		}
 		$this->jobs[] = $job;
 	}
 
-    /**
-     * @param string|int $key
-     */
+	/**
+	 * @param string|int $key
+	 */
 	public function get($key): ?IJob
 	{
-		return isset($this->jobs[$key]) ? $this->jobs[$key] : NULL;
+		return $this->jobs[$key] ?? null;
 	}
 
 	/**
@@ -56,9 +56,9 @@ class Scheduler implements IScheduler
 		return $this->jobs;
 	}
 
-    /**
-     * @param string|int $key
-     */
+	/**
+	 * @param string|int $key
+	 */
 	public function remove($key): void
 	{
 		unset($this->jobs[$key]);

--- a/tests/DI/SchedulerExtensionTest.php
+++ b/tests/DI/SchedulerExtensionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Tests\Contributte\Scheduler;
 
 use Contributte\Scheduler\DI\SchedulerExtension;
@@ -11,10 +13,7 @@ use Nette\DI\ContainerLoader;
 final class SchedulerExtensionTest extends MockeryTest
 {
 
-	/**
-	 * @return void
-	 */
-	public function testRegister()
+	public function testRegister(): void
 	{
 		$loader = new ContainerLoader(__DIR__ . '/temp', TRUE);
 		$class = $loader->load(function (Compiler $compiler) {

--- a/tests/DI/SchedulerExtensionTest.php
+++ b/tests/DI/SchedulerExtensionTest.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace Tests\Contributte\Scheduler;
 
@@ -15,8 +13,8 @@ final class SchedulerExtensionTest extends MockeryTest
 
 	public function testRegister(): void
 	{
-		$loader = new ContainerLoader(__DIR__ . '/temp', TRUE);
-		$class = $loader->load(function (Compiler $compiler) {
+		$loader = new ContainerLoader(__DIR__ . '/temp', true);
+		$class = $loader->load(function (Compiler $compiler): void {
 			$compiler->addConfig([
 				'parameters' => [
 					'tempDir' => '',
@@ -25,7 +23,7 @@ final class SchedulerExtensionTest extends MockeryTest
 			$compiler->addExtension('scheduler', new SchedulerExtension());
 		});
 		/** @var Container $container */
-		$container = new $class;
+		$container = new $class();
 		self::assertInstanceOf(IScheduler::class, $container->getByType(IScheduler::class));
 	}
 

--- a/tests/MockeryTest.php
+++ b/tests/MockeryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Tests\Contributte\Scheduler;
 
 use Mockery;
@@ -8,10 +10,7 @@ use PHPUnit\Framework\TestCase;
 abstract class MockeryTest extends TestCase
 {
 
-	/**
-	 * @return void
-	 */
-	protected function tearDown()
+	protected function tearDown(): void
 	{
 		Mockery::close();
 	}

--- a/tests/MockeryTest.php
+++ b/tests/MockeryTest.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace Tests\Contributte\Scheduler;
 

--- a/tests/SchedulerTest.php
+++ b/tests/SchedulerTest.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace Tests\Contributte\Scheduler;
 
@@ -17,7 +15,7 @@ final class SchedulerTest extends MockeryTest
 		/** @var MockInterface|IJob $pendingJob */
 		$pendingJob = Mockery::mock(IJob::class)
 			->shouldReceive('isDue')
-			->andReturn(FALSE)
+			->andReturn(false)
 			->once()
 			->getMock()
 			->shouldNotReceive('run')
@@ -26,7 +24,7 @@ final class SchedulerTest extends MockeryTest
 		/** @var MockInterface|IJob $readyJob */
 		$readyJob = Mockery::mock(IJob::class)
 			->shouldReceive('isDue')
-			->andReturn(TRUE)
+			->andReturn(true)
 			->once()
 			->getMock()
 			->shouldReceive('run')

--- a/tests/SchedulerTest.php
+++ b/tests/SchedulerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Tests\Contributte\Scheduler;
 
 use Contributte\Scheduler\IJob;
@@ -10,10 +12,7 @@ use Mockery\MockInterface;
 final class SchedulerTest extends MockeryTest
 {
 
-	/**
-	 * @return void
-	 */
-	public function testRun()
+	public function testRun(): void
 	{
 		/** @var MockInterface|IJob $pendingJob */
 		$pendingJob = Mockery::mock(IJob::class)
@@ -42,10 +41,7 @@ final class SchedulerTest extends MockeryTest
 		$scheduler->run();
 	}
 
-	/**
-	 * @return void
-	 */
-	public function testManage()
+	public function testManage(): void
 	{
 		/** @var MockInterface|IJob $foo */
 		$foo = Mockery::mock(IJob::class);


### PR DESCRIPTION
Dropped compatibility with php 5.6 and 7.0
Added strict types
Latest symfony/console allowed
Dropped unuseful annotations (where were same as php native typehint)
~~Replaced DateTime with DateTimeInterface~~ - not possible, not supported by https://github.com/dragonmantank/cron-expression