### PR TITLE
Fix list command on empty key

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -87,6 +87,7 @@ And don't forget register it.
 scheduler:
     jobs:
         - App\Model\MyAwesomeJob
+        myOtherJob: App\Model\MyOtherJob
 ```
 
 ## Commands

--- a/src/Command/ListCommand.php
+++ b/src/Command/ListCommand.php
@@ -37,7 +37,7 @@ class ListCommand extends Command
 		$table->setHeaders(['Key', 'Type', 'Is due', 'Cron', 'Callback']);
 		$dateTime = new DateTime();
 		foreach ($jobs as $key => $job) {
-			$table->addRow(self::formatRow($key, $job, $dateTime));
+			$table->addRow(self::formatRow(is_string($key) ? $key : '', $job, $dateTime));
 		}
 		$table->render();
 		return 0;

--- a/src/DI/SchedulerExtension.php
+++ b/src/DI/SchedulerExtension.php
@@ -51,7 +51,7 @@ class SchedulerExtension extends CompilerExtension
 			} else {
 				$job = new Statement($job);
 			}
-			$scheduler->addSetup('add', [$job, is_string($key) ? $key : '']);
+			$scheduler->addSetup('add', [$job, $key]);
 		}
 	}
 

--- a/src/DI/SchedulerExtension.php
+++ b/src/DI/SchedulerExtension.php
@@ -45,13 +45,13 @@ class SchedulerExtension extends CompilerExtension
 			->setAutowired(false);
 
 		// Jobs
-		foreach ($config['jobs'] as $job) {
+		foreach ($config['jobs'] as $key => $job) {
 			if (is_array($job)) {
 				$job = new Statement(CallbackJob::class, [$job['cron'], $job['callback']]);
 			} else {
 				$job = new Statement($job);
 			}
-			$scheduler->addSetup('add', [$job]);
+			$scheduler->addSetup('add', [$job, is_string($key) ? $key : '']);
 		}
 	}
 


### PR DESCRIPTION
The list command was failing when custom jobs did not have set key in config and the key was not passed to Schedulers add method so it was impossible to use custom jobs. Now if the key is not set, it just does not print anything in key column.

```bash
 Type error: Argument 1 passed to Contributte\Scheduler\Command\ListCommand::formatRow() must be of the type string, integer given, called in vendor/contributte/scheduler/src/Command  
  /ListCommand.php on line 40
```