### PR TITLE
Last-run feature

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     "php": ">=7.2",
     "contributte/di": "^0.5",
     "dragonmantank/cron-expression": "^3.0.1",
+    "nette/safe-stream": "^2.4",
     "symfony/console": "^5.0.0"
   },
   "require-dev": {

--- a/src/ExpressionJob.php
+++ b/src/ExpressionJob.php
@@ -4,6 +4,7 @@ namespace Contributte\Scheduler;
 
 use Cron\CronExpression;
 use DateTime;
+use DateTimeInterface;
 
 abstract class ExpressionJob implements IJob
 {

--- a/src/ExpressionJob.php
+++ b/src/ExpressionJob.php
@@ -17,7 +17,7 @@ abstract class ExpressionJob implements IJob
 		$this->expression = new CronExpression($cron);
 	}
 
-	public function isDue(DateTime $dateTime, DateTimeInterface $lastCheck = null): bool
+	public function isDue(DateTime $dateTime, ?DateTimeInterface $lastCheck = null): bool
 	{
 		return (
 			$this->expression->isDue($dateTime)

--- a/src/ExpressionJob.php
+++ b/src/ExpressionJob.php
@@ -16,11 +16,11 @@ abstract class ExpressionJob implements IJob
 		$this->expression = new CronExpression($cron);
 	}
 
-	public function isDue(DateTime $dateTime, DateTimeInterface $lastRun = null): bool
+	public function isDue(DateTime $dateTime, DateTimeInterface $lastCheck = null): bool
 	{
 		return (
 			$this->expression->isDue($dateTime)
-			|| ($lastRun !== null && $lastRun < $this->expression->getPreviousRunDate($dateTime))
+			|| ($lastCheck !== null && $lastCheck < $this->expression->getPreviousRunDate($dateTime))
 		);
 	}
 

--- a/src/ExpressionJob.php
+++ b/src/ExpressionJob.php
@@ -16,9 +16,12 @@ abstract class ExpressionJob implements IJob
 		$this->expression = new CronExpression($cron);
 	}
 
-	public function isDue(DateTime $dateTime): bool
+	public function isDue(DateTime $dateTime, DateTimeInterface $lastRun = null): bool
 	{
-		return $this->expression->isDue($dateTime);
+		return (
+			$this->expression->isDue($dateTime)
+			|| ($lastRun !== null && $lastRun < $this->expression->getPreviousRunDate($dateTime))
+		);
 	}
 
 	public function getExpression(): CronExpression

--- a/src/ExpressionJob.php
+++ b/src/ExpressionJob.php
@@ -19,10 +19,7 @@ abstract class ExpressionJob implements IJob
 
 	public function isDue(DateTime $dateTime, ?DateTimeInterface $lastCheck = null): bool
 	{
-		return (
-			$this->expression->isDue($dateTime)
-			|| ($lastCheck !== null && $lastCheck < $this->expression->getPreviousRunDate($dateTime))
-		);
+		return $this->expression->isDue($dateTime) || ($lastCheck !== null && $lastCheck < $this->expression->getPreviousRunDate($dateTime));
 	}
 
 	public function getExpression(): CronExpression

--- a/src/IJob.php
+++ b/src/IJob.php
@@ -3,6 +3,7 @@
 namespace Contributte\Scheduler;
 
 use DateTime;
+use DateTimeInterface;
 
 interface IJob
 {

--- a/src/IJob.php
+++ b/src/IJob.php
@@ -7,7 +7,7 @@ use DateTime;
 interface IJob
 {
 
-	public function isDue(DateTime $dateTime): bool;
+	public function isDue(DateTime $dateTime, DateTimeInterface $lastRun = null): bool;
 
 	public function run(): void;
 

--- a/src/IJob.php
+++ b/src/IJob.php
@@ -8,7 +8,7 @@ use DateTimeInterface;
 interface IJob
 {
 
-	public function isDue(DateTime $dateTime, DateTimeInterface $lastCheck = null): bool;
+	public function isDue(DateTime $dateTime, ?DateTimeInterface $lastCheck = null): bool;
 
 	public function run(): void;
 

--- a/src/IJob.php
+++ b/src/IJob.php
@@ -7,7 +7,7 @@ use DateTime;
 interface IJob
 {
 
-	public function isDue(DateTime $dateTime, DateTimeInterface $lastRun = null): bool;
+	public function isDue(DateTime $dateTime, DateTimeInterface $lastCheck = null): bool;
 
 	public function run(): void;
 

--- a/src/LockingScheduler.php
+++ b/src/LockingScheduler.php
@@ -63,9 +63,12 @@ class LockingScheduler extends Scheduler
 	{
 		$file = $this->buildLastRunFilePath();
 		if (file_exists($file)) {
-			$lastRun = DateTime::createFromFormat('U', file_get_contents($file));
+			$lastRun = file_get_contents($file);
 			if ($lastRun !== false) {
-				return $lastRun;
+				$lastRun = DateTime::createFromFormat('U', $lastRun);
+				if ($lastRun !== false) {
+					return $lastRun;
+				}
 			}
 		}
 

--- a/src/LockingScheduler.php
+++ b/src/LockingScheduler.php
@@ -4,6 +4,7 @@ namespace Contributte\Scheduler;
 
 use Contributte\Scheduler\Helpers\Debugger;
 use DateTime;
+use Nette\Utils\SafeStream;
 use RuntimeException;
 use Throwable;
 
@@ -51,6 +52,11 @@ class LockingScheduler extends Scheduler
 				unlink($this->path . '/' . $id . '.lock');
 			}
 		}
+	}
+
+	private function buildLastRunFilePath(): string
+	{
+		return SafeStream::PROTOCOL . '://' . $this->path . '/last-run';
 	}
 
 }

--- a/src/LockingScheduler.php
+++ b/src/LockingScheduler.php
@@ -26,11 +26,13 @@ class LockingScheduler extends Scheduler
 			throw new RuntimeException(sprintf('Directory `%s` was not created', $this->path));
 		}
 
+		$lastRun = $this->loadLastRunTime();
+
 		$dateTime = new DateTime();
 		$jobs = $this->jobs;
 
 		foreach ($jobs as $id => $job) {
-			if (!$job->isDue($dateTime)) {
+			if (!$job->isDue($dateTime, $lastRun)) {
 				continue;
 			}
 
@@ -53,6 +55,8 @@ class LockingScheduler extends Scheduler
 				unlink($this->path . '/' . $id . '.lock');
 			}
 		}
+
+		$this->saveLastRunTime($dateTime);
 	}
 
 	private function loadLastRunTime(): ?DateTimeInterface

--- a/src/LockingScheduler.php
+++ b/src/LockingScheduler.php
@@ -4,6 +4,7 @@ namespace Contributte\Scheduler;
 
 use Contributte\Scheduler\Helpers\Debugger;
 use DateTime;
+use DateTimeInterface;
 use Nette\Utils\SafeStream;
 use RuntimeException;
 use Throwable;
@@ -52,6 +53,25 @@ class LockingScheduler extends Scheduler
 				unlink($this->path . '/' . $id . '.lock');
 			}
 		}
+	}
+
+	private function loadLastRunTime(): ?DateTimeInterface
+	{
+		$file = $this->buildLastRunFilePath();
+		if (file_exists($file)) {
+			$lastRun = DateTime::createFromFormat('U', file_get_contents($file));
+			if ($lastRun !== false) {
+				return $lastRun;
+			}
+		}
+
+		return null;
+	}
+
+	private function saveLastRunTime(DateTimeInterface $now): void
+	{
+		$file = $this->buildLastRunFilePath();
+		file_put_contents($file, $now->format('U'));
 	}
 
 	private function buildLastRunFilePath(): string

--- a/tests/fixtures/CustomJob.php
+++ b/tests/fixtures/CustomJob.php
@@ -9,7 +9,7 @@ use DateTimeInterface;
 final class CustomJob implements IJob
 {
 
-	public function isDue(DateTime $dateTime, DateTimeInterface $lastCheck = null): bool
+	public function isDue(DateTime $dateTime, ?DateTimeInterface $lastCheck = null): bool
 	{
 		return true;
 	}

--- a/tests/fixtures/CustomJob.php
+++ b/tests/fixtures/CustomJob.php
@@ -4,11 +4,12 @@ namespace Tests\Fixtures;
 
 use Contributte\Scheduler\IJob;
 use DateTime;
+use DateTimeInterface;
 
 final class CustomJob implements IJob
 {
 
-	public function isDue(DateTime $dateTime): bool
+	public function isDue(DateTime $dateTime, DateTimeInterface $lastCheck = null): bool
 	{
 		return true;
 	}


### PR DESCRIPTION
Hello all,

I cannot always run the scheduler each minute, so I was missing the option to run the jobs during the next run.

I have added into `LockingScheduler` the ability to store last-run timestamp (heavily inspired by baraja-core/cronner, but only scheduler-level, as I do not need it in the job-level). I have used this scheduler as it already has configured a directory for storing its locks. If I should implemented it in a separate Scheduler, please, let me know.

Due to this, a change in the IJob definition was needed. If it should be done backward-compatible (though the package is in 0.x version), I could reimplement it using another interface.

The documentation is not edited (yet, would like to hear from You first).

Thank You for Your response.

Best regards